### PR TITLE
Change target link library from QVTK to vtkGUISupportQt-6.1 for compatib...

### DIFF
--- a/qtgui/CMakeLists.txt
+++ b/qtgui/CMakeLists.txt
@@ -32,7 +32,7 @@ ELSE()
     add_executable(denali ${SOURCES} ${HEADERS_MOC} ${UI_SRCS})
 ENDIF()
 
-target_link_libraries(denali ${QT_LIBRARIES} ${VTK_LIBRARIES} QVTK)
+target_link_libraries(denali ${QT_LIBRARIES} ${VTK_LIBRARIES} vtkGUISupportQt-6.1)
 
 install(TARGETS denali DESTINATION bin)
 install(FILES startlogo.png DESTINATION share/denali)

--- a/qtgui/landscape_interface.h
+++ b/qtgui/landscape_interface.h
@@ -37,6 +37,7 @@
 #include <vtkDataSetMapper.h>
 #include <vtkElevationFilter.h>
 #include <vtkImageActor.h>
+#include <vtkImageMapper3D.h>
 #include <vtkInteractorStyleTerrain.h>
 #include <vtkInteractorStyleTrackballCamera.h>
 #include <vtkLookupTable.h>
@@ -373,7 +374,7 @@ public:
             vtkSmartPointer<vtkImageActor> image_actor =
                     vtkSmartPointer<vtkImageActor>::New();
 
-            image_actor->SetInput(png_reader->GetOutput());
+            image_actor->GetMapper()->SetInput(png_reader->GetOutputPort());
 
             _bg_renderer->AddActor(image_actor);
         }


### PR DESCRIPTION
...ility with newer VTK version.

Not sure if you actually want to accept this, but this was a necessary change for me to get denali working with VTK 6.1. With the old text, ld failed with a linker error for -lQVTK because newer VTK's don't create a libQVTK.so. Ideally you could make CMake support whichever one is found, but I don't know how to implement that.
